### PR TITLE
(feat): Add postcss support to webpack storybooks

### DIFF
--- a/docs/getting-started/tailwind.md
+++ b/docs/getting-started/tailwind.md
@@ -41,7 +41,10 @@ module.exports = {
 
 ### 📝 Using PostCSS?
 
-If your project uses webpack and postCSS you will need to add the `@storybook/addon-postcss` addon as well. To do this, install it as a dependency and add it to your `.storybook/main.js` file.
+Using Vite, `@storybook/nextjs`, or `@storybook/preset-create-react-app` with `react-scripts@2.0.0` and up? **You can skip this step.**
+
+In some cases, Storybook with webpack isn't set up to use PostCSS, which is the Tailwind team's recommended approach to processing Tailwind. In these cases, let
+`@storybook/addon-styling` know to use postCSS.
 
 ```diff
 module.exports = {
@@ -51,8 +54,13 @@ module.exports = {
   ],
   addons: [
     "@storybook/addon-essentials",
-+   "@storybook/addon-postcss"
-    "@storybook/addon-styling"
+-   "@storybook/addon-styling"
++   {
++     name: "@storybook/addon-styling",
++     options: {
++       postCss: true,
++     },
++   },
   ],
 };
 ```

--- a/preset.js
+++ b/preset.js
@@ -1,3 +1,5 @@
+const { webpackFinal } = require.resolve("./dist/esm/preset/webpack");
+
 function config(entry = []) {
   return [...entry, require.resolve("./dist/esm/preset/preview")];
 }
@@ -9,4 +11,5 @@ function managerEntries(entry = []) {
 module.exports = {
   managerEntries,
   config,
+  webpackFinal,
 };

--- a/preset.js
+++ b/preset.js
@@ -1,4 +1,4 @@
-const { webpackFinal } = require.resolve("./dist/esm/preset/webpack");
+const { webpackFinal } = require("./dist/esm/preset/webpack");
 
 function config(entry = []) {
   return [...entry, require.resolve("./dist/esm/preset/preview")];

--- a/src/preset/webpack/helpers.ts
+++ b/src/preset/webpack/helpers.ts
@@ -10,9 +10,9 @@ const buildStyleLoader = (options: AddonStylingOptions) => ({
   loader: "style-loader",
 });
 
-const buildCssLoader = ({ useCssModules, usePostCss }: AddonStylingOptions) => {
-  const importSettings = usePostCss ? { importLoaders: 1 } : {};
-  const moduleSettings = useCssModules ? { modules: "auto" } : {};
+const buildCssLoader = ({ cssModules, postCss }: AddonStylingOptions) => {
+  const importSettings = postCss ? { importLoaders: 1 } : {};
+  const moduleSettings = cssModules ? { modules: "auto" } : {};
 
   return {
     loader: "css-loader",
@@ -23,10 +23,9 @@ const buildCssLoader = ({ useCssModules, usePostCss }: AddonStylingOptions) => {
   };
 };
 
-const buildPostCssLoader = ({
-  postCssImplementation: implementation,
-}: AddonStylingOptions) => {
-  const implementationOptions = implementation ? { implementation } : {};
+const buildPostCssLoader = ({ postCss }: AddonStylingOptions) => {
+  const implementationOptions =
+    typeof postCss === "object" ? { ...postCss } : {};
 
   return {
     loader: "postcss-loader",
@@ -43,7 +42,7 @@ export const buildCssRule = (options: AddonStylingOptions): RuleSetRule => {
   const buildRule = [
     buildStyleLoader(options),
     buildCssLoader(options),
-    ...(options.usePostCss ? [buildPostCssLoader(options)] : []),
+    ...(options.postCss ? [buildPostCssLoader(options)] : []),
   ];
   return {
     test: CSS_FILE_REGEX,

--- a/src/preset/webpack/helpers.ts
+++ b/src/preset/webpack/helpers.ts
@@ -1,0 +1,52 @@
+import type { RuleSetRule } from "webpack";
+import { AddonStylingOptions } from "./types";
+
+export const isRuleForCSS = (rule: RuleSetRule) =>
+  typeof rule !== "string" &&
+  rule.test instanceof RegExp &&
+  rule.test.test("test.css");
+
+const buildStyleLoader = (options: AddonStylingOptions) => ({
+  loader: "style-loader",
+});
+
+const buildCssLoader = ({ useCssModules, usePostCss }: AddonStylingOptions) => {
+  const importSettings = usePostCss ? { importLoaders: 1 } : {};
+  const moduleSettings = useCssModules ? { modules: "auto" } : {};
+
+  return {
+    loader: "css-loader",
+    options: {
+      ...importSettings,
+      ...moduleSettings,
+    },
+  };
+};
+
+const buildPostCssLoader = ({
+  postCssImplementation: implementation,
+}: AddonStylingOptions) => {
+  const implementationOptions = implementation ? { implementation } : {};
+
+  return {
+    loader: "postcss-loader",
+    options: {
+      ...implementationOptions,
+    },
+  };
+};
+
+const CSS_FILE_REGEX = /\.css$/;
+export const buildCssRule = (options: AddonStylingOptions): RuleSetRule => {
+  if (options.cssBuildRule) return options.cssBuildRule;
+
+  const buildRule = [
+    buildStyleLoader(options),
+    buildCssLoader(options),
+    ...(options.usePostCss ? [buildPostCssLoader(options)] : []),
+  ];
+  return {
+    test: CSS_FILE_REGEX,
+    use: buildRule,
+  };
+};

--- a/src/preset/webpack/index.ts
+++ b/src/preset/webpack/index.ts
@@ -3,7 +3,7 @@ import type { Configuration as WebpackConfig } from "webpack";
 import { buildCssRule, isRuleForCSS } from "./helpers";
 import type { AddonStylingOptions } from "./types";
 
-export async function webpackFinal(
+export function webpackFinal(
   config: WebpackConfig,
   options: AddonStylingOptions = {}
 ) {

--- a/src/preset/webpack/index.ts
+++ b/src/preset/webpack/index.ts
@@ -1,0 +1,30 @@
+import type { Configuration as WebpackConfig } from "webpack";
+
+import { buildCssRule, isRuleForCSS } from "./helpers";
+import type { AddonStylingOptions } from "./types";
+
+export async function webpackFinal(
+  config: WebpackConfig,
+  options: AddonStylingOptions = {}
+) {
+  // If the user doesn't want to patch webpack for postcss or css modules
+  if (!options.usePostCss && !options.useCssModules) {
+    // return config unchanged
+    return config;
+  }
+
+  const rules = config.module?.rules;
+
+  const cssRule = buildCssRule(options);
+  const ruleIndex = rules?.findIndex(isRuleForCSS);
+
+  if (ruleIndex === -1) {
+    // If no existing css rule, add it
+    rules?.push(cssRule);
+  } else {
+    // If existing css rule, replace it
+    rules[ruleIndex] = cssRule;
+  }
+
+  return config;
+}

--- a/src/preset/webpack/index.ts
+++ b/src/preset/webpack/index.ts
@@ -8,7 +8,7 @@ export function webpackFinal(
   options: AddonStylingOptions = {}
 ) {
   // If the user doesn't want to patch webpack for postcss or css modules
-  if (!options.usePostCss && !options.useCssModules) {
+  if (!options.postCss && !options.cssModules && !options.cssBuildRule) {
     // return config unchanged
     return config;
   }

--- a/src/preset/webpack/types.ts
+++ b/src/preset/webpack/types.ts
@@ -1,0 +1,8 @@
+import type { RuleSetRule } from "webpack";
+
+export interface AddonStylingOptions {
+  usePostCss?: boolean;
+  postCssImplementation?: unknown;
+  useCssModules?: boolean;
+  cssBuildRule?: RuleSetRule;
+}

--- a/src/preset/webpack/types.ts
+++ b/src/preset/webpack/types.ts
@@ -1,8 +1,7 @@
 import type { RuleSetRule } from "webpack";
 
 export interface AddonStylingOptions {
-  usePostCss?: boolean;
-  postCssImplementation?: unknown;
-  useCssModules?: boolean;
+  postCss?: boolean | object;
+  cssModules?: boolean;
   cssBuildRule?: RuleSetRule;
 }


### PR DESCRIPTION
## What changed
- Add support to add PostCSS into the webpack build

## How to test

- Have a `postcss.config.js` file
```js
module.exports = {
  plugins: {
    tailwindcss: {},
    autoprefixer: {},
  },
};
```

- Import your global tailwind css file into `.storybook/preview.js`
- Run `yarn add -D @storybook/addon-styling@0.2.0-canary.3.524da34.0`
- Register the addon in `.storybook/main.js`
```diff
module.exports = {
  stories: [
    "../stories/**/*.stories.mdx",
    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
  ],
  addons: [
    "@storybook/addon-essentials",
+   {
+     name: "@storybook/addon-styling",
+     options: {
+       postCss: true,
+     },
+   },
  ],
};
```
- start Storybook

Still failed? what was your error?



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.0-canary.3.524da34.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-styling@0.2.0-canary.3.524da34.0
  # or 
  yarn add @storybook/addon-styling@0.2.0-canary.3.524da34.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
