### PR TITLE
Allow react 18; Update some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Get started in Storybook faster with popular styling tools.
 ## ✨ Features
 
 - 🧩 Configuration templates for popular tools
+- ⚡️ Options for css modules, postCss, and Sass
 - 🎨 Provide themes
 - 🔄 Toggle between multiple themes when more than one is provided
 - ❗️ Override theme at the component and story level through parameters
@@ -55,9 +56,12 @@ For tool-specific setup, check out the recipes below
 - [`@emotion/styled`](./docs/getting-started/emotion.md)
 - [`@mui/material`](./docs/getting-started/material-ui.md)
 - [`bootstrap`](./docs/getting-started/bootstrap.md)
+- [`cssModules`](./docs/api.md#optionscssmodules)
+- [`postcss`](./docs/api.md#optionspostcss)
+- [`sass`](./docs/api.md#optionssass)
 - [`styled-components`](./docs/getting-started/styled-components.md)
 - [`tailwind`](./docs/getting-started/tailwind.md)
-- [Vuetify 3](./docs/api.md#writing-a-custom-decorator)
+- [`vuetify@3.x`](./docs/api.md#writing-a-custom-decorator)
 
 Don't see your favorite tool listed? Don't worry! That doesn't mean this addon isn't for you. Check out the ["Writing a custom decorator"](./docs/api.md#writing-a-custom-decorator) section of the [api reference](./docs/api.md).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,127 @@
 # API
 
+## Addon options
+
+If your app is using webpack and you want to use css modules, postCss, or Sass, it's possible that you'll need to tell Storybook's webpack how to use them. Below are the options available.
+
+```ts
+// From src/preset/types.ts
+import type { RuleSetRule } from "webpack";
+
+export interface AddonStylingOptions {
+  postCss?: boolean | object;
+  sass?: object;
+  cssModules?: boolean;
+  cssBuildRule?: RuleSetRule;
+  scssBuildRule?: RuleSetRule;
+}
+```
+
+### `options.postCss`
+
+**Required?** false
+
+Setting `options.postCss` to true will enable postCss in your storybook. This will read the
+`postcss.config.js` file in the root of your project.
+
+**Using PostCss 8+**? You'll need to share your version of postCss like so:
+
+```js
+module.exports = {
+  stories: [
+    "../stories/**/*.stories.mdx",
+    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
+  addons: [
+    "@storybook/addon-essentials",
+    {
+      name: "@storybook/addon-styling",
+      options: {
+        postCss: {
+          implementation: require("postcss"),
+        },
+      },
+    },
+  ],
+};
+```
+
+### `options.sass`
+
+**Required?** false
+
+To use Sass, you'll need to install a few extra dependencies
+
+```shell
+# You can replace sass with you preferred sass preprocessor
+yarn add -D sass sass-loader resolve-url-loader
+```
+
+need to share your preferred Sass preprocessor like so:
+
+```js
+module.exports = {
+  stories: [
+    "../stories/**/*.stories.mdx",
+    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
+  addons: [
+    "@storybook/addon-essentials",
+    {
+      name: "@storybook/addon-styling",
+      options: {
+        sass: {
+          // Require your preprocessor
+          implementation: require("sass"),
+        },
+      },
+    },
+  ],
+};
+```
+
+### `options.cssModules`
+
+**Required?** false
+
+Setting `options.cssModules` to true will give you a basic setup of css modules for your css (and scss if you're using it). If you're looking for something more robust, keep reading 👇
+
+### Advanced
+
+If the above options aren't working for you, you likely have a more advanced set up.
+In those cases, you can give the addon the webpack rules for css and sass files using
+`options.cssBuildRule` and `options.scssBuildRule`.
+
+Example:
+
+```js
+module.exports = {
+  stories: [
+    "../stories/**/*.stories.mdx",
+    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
+  addons: [
+    "@storybook/addon-essentials",
+    {
+      name: "@storybook/addon-styling",
+      options: {
+        cssBuildRule: {
+          test: /\.css$/,
+          use: [
+            'style-loader',
+            {
+              loader: 'css-loader',
+              options: {...}
+            },
+            // snipped for brevity
+          ]
+        },
+      },
+    },
+  ],
+};
+```
+
 ## Decorators
 
 ### `withThemeFromJSXProvider`

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@storybook/core-events": "^6.5.8",
     "@storybook/manager-api": "^7.0.0-beta.56",
     "@storybook/theming": "^6.5.8",
-    "react": "^16.8.0 || ^17.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^10.4.1"


### PR DESCRIPTION
Solves #5

## What changed
- Add react 18 as an optional peer dependency
- Add addon options to api docs
- Add links for postcss, sass, and css modules set up to README.md