### PR TITLE
feat: Support multiple classes per theme in withThemeByClassName

### DIFF
--- a/src/decorators/class-name.strategy.tsx
+++ b/src/decorators/class-name.strategy.tsx
@@ -29,7 +29,7 @@ export const withThemeByClassName = ({
       const parentElement = document.querySelector(parentSelector);
 
       Object.entries(themes).forEach(([themeName, className]) => {
-        const classNames = className.split(' ');
+        const classNames = className.split(' ').filter(Boolean);
 
         if (themeName === selectedThemeName) {
           parentElement.classList.add(...classNames);

--- a/src/decorators/class-name.strategy.tsx
+++ b/src/decorators/class-name.strategy.tsx
@@ -29,10 +29,12 @@ export const withThemeByClassName = ({
       const parentElement = document.querySelector(parentSelector);
 
       Object.entries(themes).forEach(([themeName, className]) => {
+        const classNames = className.split(' ');
+
         if (themeName === selectedThemeName) {
-          parentElement.classList.add(className);
+          parentElement.classList.add(...classNames);
         } else {
-          parentElement.classList.remove(className);
+          parentElement.classList.remove(...classNames);
         }
       });
     }, [themeOverride, selected, parentSelector]);


### PR DESCRIPTION
In my storybook I wanted to add different Tailwind classes to `parentElement` depending on a theme. For example, dark theme would have `text-white bg-black` and white theme: `text-black bg-white`. I was surprised to see the classic `The token can not contain whitespace` exception. This PR added support for multiple classes per theme:
```ts
withThemeByClassName({
  themes: {
    dark: 'text-white bg-black',
    white: 'text-black bg-white`,
  },
  defaultTheme: 'dark',
}),