### PR TITLE
fix: Error occurs when class name to be added is empty

### DIFF
--- a/src/decorators/class-name.strategy.tsx
+++ b/src/decorators/class-name.strategy.tsx
@@ -30,6 +30,9 @@ export const withThemeByClassName = ({
       const parentElement = document.querySelector(parentSelector);
 
       Object.entries(themes).forEach(([themeName, className]) => {
+        if (!className) {
+          return;
+        }
         if (themeName === selectedThemeName) {
           parentElement.classList.add(className);
         } else {


### PR DESCRIPTION
An error occurred when using this sample.
https://github.com/storybookjs/addon-styling/blob/next/docs/getting-started/tailwind.md#-provide-your-themes

<img width="751" alt="スクリーンショット 2023-03-24 19 25 23" src="https://user-images.githubusercontent.com/61353435/227496402-f0b26c0b-7885-412c-a3a7-33e413a0e244.png">

That happens when adding an empty string to the class list, so we have made it so that it does not run with an empty string.
