### PR TITLE
make stylesheets sideEffects to stop treeshaking

### DIFF
--- a/src/webpack/css/webpack.ts
+++ b/src/webpack/css/webpack.ts
@@ -47,6 +47,7 @@ const buildCssRule = (options: AddonStylingOptions): RuleSetRule => {
   return {
     test: CSS_FILE_REGEX,
     use: buildRule,
+    sideEffects: true,
   };
 };
 

--- a/src/webpack/scss/webpack.ts
+++ b/src/webpack/scss/webpack.ts
@@ -81,6 +81,7 @@ const buildScssRule = (options: AddonStylingOptions): RuleSetRule => {
   return {
     test: SCSS_FILE_REGEX,
     use: buildRule,
+    sideEffects: true,
   };
 };
 


### PR DESCRIPTION
## What changed?
- [x] Declare stylesheets as side effects in webpack to avoid treeshaking