### PR TITLE
Add auto configs for emotion and styled components

### DIFF
--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -12,10 +12,14 @@ import { determineBuilder } from "./postinstall/utils/dependencies.utils";
 
 import { tailwindStrategy } from "./postinstall/tailwind/tailwind.strategy";
 import { materialUIStrategy } from "./postinstall/material-ui/material-ui.strategy";
+import { emotionStrategy } from "./postinstall/emotion/emotion.strategy";
+import { styledComponentsStrategy } from "./postinstall/styled-components/styled-components.strategy";
 
 const AUTO_CONFIG_STRATEGIES: ToolConfigurationStrategy[] = [
   tailwindStrategy,
   materialUIStrategy,
+  emotionStrategy,
+  styledComponentsStrategy,
 ];
 
 const selectStrategy = (packageJson: PackageJson) =>

--- a/src/postinstall/emotion/emotion.strategy.test.ts
+++ b/src/postinstall/emotion/emotion.strategy.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { PackageJson } from "@storybook/types";
+import { readConfig } from "@storybook/csf-tools";
+import { resolve } from "node:path";
+
+import { emotionStrategy } from "./emotion.strategy";
+import { SUPPORTED_BUILDERS } from "../types";
+import { formatFileContents } from "../utils/configs.utils";
+
+describe("CODEMOD: Emotion configuration", () => {
+  describe("PREDICATE: should project be configured for Emotion?", () => {
+    it("TRUE: it should return true when Emotion is found in package.json", () => {
+      const packageJson: PackageJson = {
+        dependencies: {
+          "@emotion/react": "latest",
+          "@emotion/styled": "latest",
+        },
+        devDependencies: {},
+      };
+
+      const result = emotionStrategy.predicate(packageJson);
+
+      expect(result).toBeTruthy();
+    });
+    it("FALSE: it should return false when Emotion is not found in package.json", () => {
+      const packageJson: PackageJson = {
+        dependencies: { bootstrap: "latest" },
+        devDependencies: {},
+      };
+
+      const result = emotionStrategy.predicate(packageJson);
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe("MAIN: how should storybook be configured for Emotion", () => {
+    it("REGISTER: addon-styling should be registered in the addons array without options", async () => {
+      const mainConfig = await readConfig(
+        resolve(__dirname, "../fixtures/main.fixture.ts")
+      );
+      const packageJson: PackageJson = {
+        dependencies: {
+          "@emotion/react": "latest",
+          "@emotion/styled": "latest",
+        },
+        devDependencies: { postcss: " latest" },
+      };
+
+      emotionStrategy.main(mainConfig, packageJson, SUPPORTED_BUILDERS.VITE);
+
+      const result = formatFileContents(mainConfig);
+
+      expect(result).toMatchInlineSnapshot(`
+        "import type { StorybookConfig } from \\"@storybook/react-vite\\";
+        const config: StorybookConfig = {
+          stories: [\\"../stories/**/*.stories.@(js|jsx|ts|tsx)\\"],
+          addons: [
+            \\"@storybook/addon-essentials\\",
+            {
+              name: \\"@storybook/addon-styling\\",
+              options: {},
+            },
+          ],
+          framework: {
+            name: \\"@storybook/react-vite\\",
+            options: {},
+          },
+          docs: {
+            autodocs: true,
+          },
+        };
+        export default config;
+        "
+      `);
+    });
+  });
+
+  describe("PREVIEW: how should storybook preview be configured for Emotion", () => {
+    it("CONFIGURE: Preview.ts should be updated with the imports and theme decorator", async () => {
+      const previewConfig = await readConfig(
+        resolve(__dirname, "../fixtures/preview.fixture.ts")
+      );
+      const packageJson: PackageJson = {
+        dependencies: {
+          "@emotion/react": "latest",
+          "@emotion/styled": "latest",
+        },
+        devDependencies: { postcss: " latest" },
+      };
+
+      emotionStrategy.preview(
+        previewConfig,
+        packageJson,
+        SUPPORTED_BUILDERS.WEBPACK
+      );
+
+      const result = formatFileContents(previewConfig);
+
+      expect(result).toMatchInlineSnapshot(`
+        "import type { Preview } from \\"@storybook/react\\";
+
+        import { Global, css, ThemeProvider } from \\"@emotion/react\\";
+        import { withThemeFromJSXProvider } from \\"@storybook/addon-styling\\";
+
+        /* TODO: update import for your custom theme configurations */
+        // import { lightTheme, darkTheme } from '../path/to/themes';
+
+        /* TODO: replace with your own global styles, or remove */
+        const GlobalStyles = () => (
+          <Global
+            styles={css\`
+              body {
+                font-family: \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;
+              }
+            \`}
+          />
+        );
+
+        const preview: Preview = {
+          parameters: {
+            theming: {},
+          },
+
+          decorators: [
+            // Adds global styles and theme switching support.
+            withThemeFromJSXProvider({
+              /* Uncomment for theme switching support */
+              // themes: {
+              //   light: lightTheme,
+              //   dark: darkTheme,
+              // }
+              // defaultTheme: 'light',
+              // Provider: ThemeProvider,
+              GlobalStyles,
+            }),
+          ],
+        };
+
+        export default preview;
+        "
+      `);
+    });
+  });
+});

--- a/src/postinstall/emotion/emotion.strategy.ts
+++ b/src/postinstall/emotion/emotion.strategy.ts
@@ -1,0 +1,101 @@
+import { PackageJson } from "@storybook/types";
+import { logger, colors } from "@storybook/node-logger";
+import * as t from "@babel/types";
+
+import { hasDependency } from "../utils/dependencies.utils";
+import { SUPPORTED_STYLING_TOOLS, ToolConfigurationStrategy } from "../types";
+import { addImports, stringToNode } from "../utils/babel.utils";
+
+const projectHasEmotion = (packageJson: PackageJson) =>
+  hasDependency(packageJson, "@emotion/react") &&
+  hasDependency(packageJson, "@emotion/styled");
+
+export const emotionStrategy: ToolConfigurationStrategy = {
+  name: SUPPORTED_STYLING_TOOLS.EMOTION,
+  predicate: projectHasEmotion,
+  main: (mainConfig, packageJson, builder) => {
+    logger.plain(`  • Registering ${colors.pink("@storybook/addon-styling")}.`);
+
+    const [addonConfigNode] = stringToNode`({
+      name: "@storybook/addon-styling",
+      options: {}
+    })`;
+
+    const addonsNodePath = ["addons"];
+    let addonsArrayNode = mainConfig.getFieldNode(addonsNodePath);
+
+    if (!addonsArrayNode) {
+      mainConfig.setFieldNode(addonsNodePath, t.arrayExpression());
+      addonsArrayNode = mainConfig.getFieldNode(addonsNodePath);
+    }
+
+    // @ts-expect-error
+    addonsArrayNode.elements.push(addonConfigNode);
+  },
+  preview: (previewConfig, packageJson, builder) => {
+    logger.plain(
+      `  • Adding imports for ${colors.green(
+        SUPPORTED_STYLING_TOOLS.EMOTION
+      )}, ${colors.blue("ThemeProvider")}, ${colors.blue(
+        "Global"
+      )}, and ${colors.blue("css")}`
+    );
+    logger.plain(
+      `  • Adding import for ${colors.blue(
+        "withThemeFromJSXProvider"
+      )} decorator`
+    );
+
+    const importsNode = stringToNode`
+    import { Global, css, ThemeProvider } from '@emotion/react';
+    import { withThemeFromJSXProvider } from '@storybook/addon-styling';
+
+    /* TODO: update import for your custom theme configurations */
+    // import { lightTheme, darkTheme } from '../path/to/themes';
+    
+    /* TODO: replace with your own global styles, or remove */
+    const GlobalStyles = () => (
+        <Global
+          styles={css\`
+            body {
+              font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            }
+          \`}
+        />
+      );
+    `;
+
+    addImports(previewConfig._ast, importsNode);
+
+    logger.plain(
+      `  • Adding ${colors.blue(
+        "withThemeFromJSXProvider"
+      )} decorator to config`
+    );
+    const [
+      decoratorNode,
+    ] = stringToNode`// Adds global styles and theme switching support.
+    withThemeFromJSXProvider({
+        /* Uncomment for theme switching support */
+        // themes: {
+        //   light: lightTheme,
+        //   dark: darkTheme,
+        // }
+        // defaultTheme: 'light',
+        // Provider: ThemeProvider,
+        GlobalStyles,
+      })`;
+
+    const decoratorNodePath = ["decorators"];
+    let decoratorArrayNode = previewConfig.getFieldNode(decoratorNodePath);
+
+    if (!decoratorArrayNode) {
+      previewConfig.setFieldNode(decoratorNodePath, t.arrayExpression());
+      decoratorArrayNode = previewConfig.getFieldNode(decoratorNodePath);
+    }
+
+    // @ts-expect-error
+    // There are specific types for each kind of node and only array nodes have the elements property
+    decoratorArrayNode.elements.push(decoratorNode);
+  },
+};

--- a/src/postinstall/styled-components/styled-components.strategy.test.ts
+++ b/src/postinstall/styled-components/styled-components.strategy.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { PackageJson } from "@storybook/types";
+import { readConfig } from "@storybook/csf-tools";
+import { resolve } from "node:path";
+
+import { styledComponentsStrategy } from "./styled-components.strategy";
+import { SUPPORTED_BUILDERS } from "../types";
+import { formatFileContents } from "../utils/configs.utils";
+
+describe("CODEMOD: Styled Components configuration", () => {
+  describe("PREDICATE: should project be configured for Styled Components?", () => {
+    it("TRUE: it should return true when Styled Components is found in package.json", () => {
+      const packageJson: PackageJson = {
+        dependencies: {
+          "styled-components": "latest",
+        },
+        devDependencies: {},
+      };
+
+      const result = styledComponentsStrategy.predicate(packageJson);
+
+      expect(result).toBeTruthy();
+    });
+    it("FALSE: it should return false when Styled Components is not found in package.json", () => {
+      const packageJson: PackageJson = {
+        dependencies: { bootstrap: "latest" },
+        devDependencies: {},
+      };
+
+      const result = styledComponentsStrategy.predicate(packageJson);
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe("MAIN: how should storybook be configured for Styled Components", () => {
+    it("REGISTER: addon-styling should be registered in the addons array without options", async () => {
+      const mainConfig = await readConfig(
+        resolve(__dirname, "../fixtures/main.fixture.ts")
+      );
+      const packageJson: PackageJson = {
+        dependencies: {
+          "styled-components": "latest",
+        },
+        devDependencies: { postcss: " latest" },
+      };
+
+      styledComponentsStrategy.main(
+        mainConfig,
+        packageJson,
+        SUPPORTED_BUILDERS.VITE
+      );
+
+      const result = formatFileContents(mainConfig);
+
+      expect(result).toMatchInlineSnapshot(`
+        "import type { StorybookConfig } from \\"@storybook/react-vite\\";
+        const config: StorybookConfig = {
+          stories: [\\"../stories/**/*.stories.@(js|jsx|ts|tsx)\\"],
+          addons: [
+            \\"@storybook/addon-essentials\\",
+            {
+              name: \\"@storybook/addon-styling\\",
+              options: {},
+            },
+          ],
+          framework: {
+            name: \\"@storybook/react-vite\\",
+            options: {},
+          },
+          docs: {
+            autodocs: true,
+          },
+        };
+        export default config;
+        "
+      `);
+    });
+  });
+
+  describe("PREVIEW: how should storybook preview be configured for Styled Components", () => {
+    it("CONFIGURE: Preview.ts should be updated with the imports and theme decorator", async () => {
+      const previewConfig = await readConfig(
+        resolve(__dirname, "../fixtures/preview.fixture.ts")
+      );
+      const packageJson: PackageJson = {
+        dependencies: {
+          "styled-components": "latest",
+        },
+        devDependencies: { postcss: " latest" },
+      };
+
+      styledComponentsStrategy.preview(
+        previewConfig,
+        packageJson,
+        SUPPORTED_BUILDERS.WEBPACK
+      );
+
+      const result = formatFileContents(previewConfig);
+
+      expect(result).toMatchInlineSnapshot(`
+        "import type { Preview } from \\"@storybook/react\\";
+
+        import { createGlobalStyle, ThemeProvider } from \\"styled-components\\";
+        import { withThemeFromJSXProvider } from \\"@storybook/addon-styling\\";
+
+        /* TODO: update import for your custom theme configurations */
+        // import { lightTheme, darkTheme } from '../path/to/themes';
+
+        /* TODO: replace with your own global styles, or remove */
+        const GlobalStyles = createGlobalStyle\`
+            body {
+              font-family: \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;
+            }
+          \`;
+
+        const preview: Preview = {
+          parameters: {
+            theming: {},
+          },
+
+          decorators: [
+            // Adds global styles and theme switching support.
+            withThemeFromJSXProvider({
+              /* Uncomment for theme switching support */
+              // themes: {
+              //   light: lightTheme,
+              //   dark: darkTheme,
+              // }
+              // defaultTheme: 'light',
+              // Provider: ThemeProvider,
+              GlobalStyles,
+            }),
+          ],
+        };
+
+        export default preview;
+        "
+      `);
+    });
+  });
+});

--- a/src/postinstall/styled-components/styled-components.strategy.ts
+++ b/src/postinstall/styled-components/styled-components.strategy.ts
@@ -1,0 +1,96 @@
+import { PackageJson } from "@storybook/types";
+import { logger, colors } from "@storybook/node-logger";
+import * as t from "@babel/types";
+
+import { hasDependency } from "../utils/dependencies.utils";
+import { SUPPORTED_STYLING_TOOLS, ToolConfigurationStrategy } from "../types";
+import { addImports, stringToNode } from "../utils/babel.utils";
+
+const projectHasStyledComponents = (packageJson: PackageJson) =>
+  hasDependency(packageJson, "styled-components");
+
+export const styledComponentsStrategy: ToolConfigurationStrategy = {
+  name: SUPPORTED_STYLING_TOOLS.STYLED_COMPONENTS,
+  predicate: projectHasStyledComponents,
+  main: (mainConfig, packageJson, builder) => {
+    logger.plain(`  • Registering ${colors.pink("@storybook/addon-styling")}.`);
+
+    const [addonConfigNode] = stringToNode`({
+      name: "@storybook/addon-styling",
+      options: {}
+    })`;
+
+    const addonsNodePath = ["addons"];
+    let addonsArrayNode = mainConfig.getFieldNode(addonsNodePath);
+
+    if (!addonsArrayNode) {
+      mainConfig.setFieldNode(addonsNodePath, t.arrayExpression());
+      addonsArrayNode = mainConfig.getFieldNode(addonsNodePath);
+    }
+
+    // @ts-expect-error
+    addonsArrayNode.elements.push(addonConfigNode);
+  },
+  preview: (previewConfig, packageJson, builder) => {
+    logger.plain(
+      `  • Adding imports for ${colors.green(
+        SUPPORTED_STYLING_TOOLS.EMOTION
+      )}, ${colors.blue("ThemeProvider")}, ${colors.blue(
+        "Global"
+      )}, and ${colors.blue("css")}`
+    );
+    logger.plain(
+      `  • Adding import for ${colors.blue(
+        "withThemeFromJSXProvider"
+      )} decorator`
+    );
+
+    const importsNode = stringToNode`
+    import { createGlobalStyle, ThemeProvider } from 'styled-components';
+    import { withThemeFromJSXProvider } from '@storybook/addon-styling';
+
+    /* TODO: update import for your custom theme configurations */
+    // import { lightTheme, darkTheme } from '../path/to/themes';
+    
+    /* TODO: replace with your own global styles, or remove */
+    const GlobalStyles = createGlobalStyle\`
+        body {
+          font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        }
+      \`;
+    `;
+
+    addImports(previewConfig._ast, importsNode);
+
+    logger.plain(
+      `  • Adding ${colors.blue(
+        "withThemeFromJSXProvider"
+      )} decorator to config`
+    );
+    const [
+      decoratorNode,
+    ] = stringToNode`// Adds global styles and theme switching support.
+    withThemeFromJSXProvider({
+        /* Uncomment for theme switching support */
+        // themes: {
+        //   light: lightTheme,
+        //   dark: darkTheme,
+        // }
+        // defaultTheme: 'light',
+        // Provider: ThemeProvider,
+        GlobalStyles,
+      })`;
+
+    const decoratorNodePath = ["decorators"];
+    let decoratorArrayNode = previewConfig.getFieldNode(decoratorNodePath);
+
+    if (!decoratorArrayNode) {
+      previewConfig.setFieldNode(decoratorNodePath, t.arrayExpression());
+      decoratorArrayNode = previewConfig.getFieldNode(decoratorNodePath);
+    }
+
+    // @ts-expect-error
+    // There are specific types for each kind of node and only array nodes have the elements property
+    decoratorArrayNode.elements.push(decoratorNode);
+  },
+};

--- a/src/postinstall/types.ts
+++ b/src/postinstall/types.ts
@@ -7,16 +7,18 @@ export const SUPPORTED_BUILDERS = {
 } as const;
 
 export type SupportedBuilders =
-  typeof SUPPORTED_BUILDERS[keyof typeof SUPPORTED_BUILDERS];
+  (typeof SUPPORTED_BUILDERS)[keyof typeof SUPPORTED_BUILDERS];
 
 export const SUPPORTED_STYLING_TOOLS = {
-  TAILWIND: "tailwind",
+  EMOTION: "emotion",
   MATERIAL_UI: "material-ui",
   SASS: "sass",
+  STYLED_COMPONENTS: "styled-components",
+  TAILWIND: "tailwind",
 } as const;
 
 export type SupportedStylingTools =
-  typeof SUPPORTED_STYLING_TOOLS[keyof typeof SUPPORTED_STYLING_TOOLS];
+  (typeof SUPPORTED_STYLING_TOOLS)[keyof typeof SUPPORTED_STYLING_TOOLS];
 
 export interface ToolConfigurationStrategy {
   /**


### PR DESCRIPTION
## What changed
- Add emotion and styled components to supported tools
- Write strategy and tests for emotion
- Write strategy and tests for styled-components
- Register strategies with postinstall script
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.1-canary.51.a4561b1.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-styling@1.1.1-canary.51.a4561b1.0
  # or 
  yarn add @storybook/addon-styling@1.1.1-canary.51.a4561b1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
