### PR TITLE
feat: configure css-loader options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -122,6 +122,12 @@ Setting `options.cssModules` to true will give you a basic setup of css modules 
 
 If you'd like to customize your CSS Module configuration, `options.cssModules` can also take an object that takes the same options as webpack's `css-loader` [modules property](https://www.npmjs.com/package/css-loader#modules).
 
+### `options.css`
+
+**Required?** false
+
+If you'd like to customize your CSS-loader configuration, `options.css` can take an object that takes the same options as [css-loader](https://www.npmjs.com/package/css-loader#options).
+
 ### Advanced
 
 If the above options aren't working for you, you likely have a more advanced set up.

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ interface LessConfig {
 
 export interface AddonStylingOptions {
   cssBuildRule?: RuleSetRule;
+  css?: Record<string, any>;
   cssModules?: boolean | Record<string, any>;
   less?: LessConfig;
   lessBuildRule?: RuleSetRule;

--- a/src/webpack/css/webpack.test.ts
+++ b/src/webpack/css/webpack.test.ts
@@ -102,6 +102,16 @@ describe("WEBPACK/CSS: configuration builders for css files", () => {
       expect(result).toMatchObject(BASE_LOADER);
     });
 
+    it('CSS OPTIONS: it should configure the css-loader with extra options', async ({ expect }) => {
+      const expected = {
+        ...BASE_LOADER,
+        options: { url: false },
+      };
+
+      const result = buildCssLoader({ css: {url: false} });
+      expect(result).toMatchObject(expected)
+    })
+
     it("POSTCSS ENABLED: it should configure the css-loader to handle imports AFTER postcss", async ({
       expect,
     }) => {
@@ -116,6 +126,19 @@ describe("WEBPACK/CSS: configuration builders for css files", () => {
 
       expect(result).toMatchObject(expected);
     });
+
+    it('CSS OPTIONS & POSTCSS enabled: it should configure the css-loader with extra options', async ({ expect }) => {
+      const expected = {
+        ...BASE_LOADER,
+        options: { importLoaders: 1, url: false },
+      };
+
+      const result = buildCssLoader({
+        css: {url: false},
+        postCss: { implementation: require.resolve("postcss") },
+      });
+      expect(result).toMatchObject(expected)
+    })
 
     it("CSS MODULES ENABLED: it should configure the css-loader to support css-modules", async ({
       expect,

--- a/src/webpack/css/webpack.ts
+++ b/src/webpack/css/webpack.ts
@@ -21,10 +21,11 @@ export const buildCssModuleRules = ({ cssModules }: AddonStylingOptions) => {
 };
 
 export const buildCssLoader = ({
+  css,
   cssModules,
   postCss,
 }: AddonStylingOptions) => {
-  const importSettings = postCss ? { importLoaders: 1 } : {};
+  const importSettings = postCss ? { importLoaders: 1, ...css } : { ...css };
   const moduleSettings = buildCssModuleRules({ cssModules });
 
   return {


### PR DESCRIPTION
First of all, thank you for building this great add-on!

We'd like to be able to configure the css-loader more extensively using css-loader's available [options](https://webpack.js.org/loaders/css-loader/#options).

We can already use `cssBuildRule` or use storybooks `webpackFinal` configuration option, but that could lead to awkward code when having to set some simple options.

This PR would enable us to do.
```
// example
{
      name: '@storybook/addon-styling',
      options: {
        css: {
          url: false
         },
      },
},
```

Please let me know if you'd like to see anything changed :-).


