### PR TITLE
Don't configure styles for nextjs

### DIFF
--- a/src/postinstall/fixtures/main.nextjs.fixture.ts
+++ b/src/postinstall/fixtures/main.nextjs.fixture.ts
@@ -1,0 +1,13 @@
+import type { StorybookConfig } from "@storybook/nextjs";
+const config: StorybookConfig = {
+  stories: ["../stories/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: ["@storybook/addon-essentials"],
+  framework: {
+    name: "@storybook/nextjs",
+    options: {},
+  },
+  docs: {
+    autodocs: true,
+  },
+};
+export default config;

--- a/src/postinstall/tailwind/tailwind.strategy.test.ts
+++ b/src/postinstall/tailwind/tailwind.strategy.test.ts
@@ -152,6 +152,43 @@ describe("CODEMOD: tailwind configuration", () => {
     });
   });
 
+  it("NextJS: addon-styling should be registered without options", async () => {
+    const mainConfig = await readConfig(
+      resolve(__dirname, "../fixtures/main.nextjs.fixture.ts")
+    );
+    const packageJson: PackageJson = {
+      dependencies: { tailwindcss: "latest" },
+      devDependencies: { postcss: " latest" },
+    };
+
+    tailwindStrategy.main(mainConfig, packageJson, SUPPORTED_BUILDERS.WEBPACK);
+
+    const result = formatFileContents(mainConfig);
+
+    expect(result).toMatchInlineSnapshot(`
+      "import type { StorybookConfig } from \\"@storybook/nextjs\\";
+      const config: StorybookConfig = {
+        stories: [\\"../stories/**/*.stories.@(js|jsx|ts|tsx)\\"],
+        addons: [
+          \\"@storybook/addon-essentials\\",
+          {
+            name: \\"@storybook/addon-styling\\",
+            options: {},
+          },
+        ],
+        framework: {
+          name: \\"@storybook/nextjs\\",
+          options: {},
+        },
+        docs: {
+          autodocs: true,
+        },
+      };
+      export default config;
+      "
+    `);
+  });
+
   describe("PREVIEW: how should storybook preview be configured for tailwind", () => {
     it("CONFIGURATION: Preview.ts should be updated with the style import todo, as well as the theme decorator", async () => {
       const previewConfig = await readConfig(

--- a/src/postinstall/tailwind/tailwind.strategy.ts
+++ b/src/postinstall/tailwind/tailwind.strategy.ts
@@ -2,7 +2,11 @@ import { PackageJson } from "@storybook/types";
 import { logger, colors } from "@storybook/node-logger";
 import * as t from "@babel/types";
 
-import { hasDependency, isAngular } from "../utils/dependencies.utils";
+import {
+  hasDependency,
+  isAngular,
+  isNextJs,
+} from "../utils/dependencies.utils";
 import {
   SUPPORTED_BUILDERS,
   SUPPORTED_STYLING_TOOLS,
@@ -21,13 +25,18 @@ export const tailwindStrategy: ToolConfigurationStrategy = {
     logger.plain(`  • Registering ${colors.pink("@storybook/addon-styling")}.`);
 
     const usingAngular = isAngular(mainConfig);
+    const usingNextJs = isNextJs(mainConfig);
 
-    if (builder === SUPPORTED_BUILDERS.WEBPACK || usingAngular) {
+    if (
+      builder === SUPPORTED_BUILDERS.WEBPACK &&
+      !usingAngular &&
+      !usingNextJs
+    ) {
       logger.plain(`    • Configuring ${colors.green("postcss")}.`);
     }
 
     const [addonConfigNode] =
-      builder === SUPPORTED_BUILDERS.VITE || usingAngular
+      builder === SUPPORTED_BUILDERS.VITE || usingAngular || usingNextJs
         ? stringToNode`({
       name: "@storybook/addon-styling",
       options: {}

--- a/src/postinstall/utils/dependencies.utils.ts
+++ b/src/postinstall/utils/dependencies.utils.ts
@@ -13,11 +13,16 @@ export const hasDependency = (
   return !!deps[depName] || !!devDeps[depName] || !!peerDeps[depName];
 };
 
-export const determineBuilder = (mainConfig: ConfigFile): SupportedBuilders => {
+export const getFramework = (mainConfig: ConfigFile): string => {
   const frameworkValue = mainConfig.getFieldValue(["framework"]);
 
-  const framework =
-    typeof frameworkValue === "string" ? frameworkValue : frameworkValue?.name;
+  return typeof frameworkValue === "string"
+    ? frameworkValue
+    : frameworkValue?.name;
+};
+
+export const determineBuilder = (mainConfig: ConfigFile): SupportedBuilders => {
+  const framework = getFramework(mainConfig);
 
   return framework.includes("vite") || framework.includes("sveltekit")
     ? SUPPORTED_BUILDERS.VITE
@@ -25,12 +30,15 @@ export const determineBuilder = (mainConfig: ConfigFile): SupportedBuilders => {
 };
 
 export const isAngular = (mainConfig: ConfigFile): boolean => {
-  const frameworkValue = mainConfig.getFieldValue(["framework"]);
-
-  const framework =
-    typeof frameworkValue === "string" ? frameworkValue : frameworkValue?.name;
+  const framework = getFramework(mainConfig);
 
   return framework.includes("angular");
+};
+
+export const isNextJs = (mainConfig: ConfigFile): boolean => {
+  const framework = getFramework(mainConfig);
+
+  return framework.includes("nextjs");
 };
 
 export const needsCssModulesConfiguration = (builder: SupportedBuilders) =>


### PR DESCRIPTION
Closes #70 

## What changed
- Add `isNextJs` helper function
- Skip `main.ts` configuration if using NextJS and tailwind
- Had tests to make sure that NextJS projects are not configured for tailwind