### PR TITLE
fix: @storybook/addon-styling in CJS require environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,16 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
+    "./dist/manager.js": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./dist/preview.js": {
+      "require": "./dist/preview.js",
+      "import": "./dist/preview.mjs",
+      "types": "./dist/preview.d.ts"
+    },
     "./manager": {
       "require": "./dist/manager.js",
       "import": "./dist/manager.mjs",

--- a/preset.js
+++ b/preset.js
@@ -1,5 +1,1 @@
-export const previewAnnotations = [require.resolve("./dist/preview")];
-
-export const managerEntries = [require.resolve("./dist/manager")];
-
-export * from "./dist/preset";
+module.exports = require("./dist/preset");

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -4,3 +4,11 @@ import { viteFinal as vite } from "./vite/viteFinal";
 export const webpackFinal = webpack as any;
 
 export const viteFinal = vite as any;
+
+export const previewAnnotations = [
+  require.resolve("@storybook/addon-styling/preview"),
+];
+
+export const managerEntries = [
+  require.resolve("@storybook/addon-styling/manager"),
+];


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.5--canary.77.5a17baa.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-styling@1.3.5--canary.77.5a17baa.0
  # or 
  yarn add @storybook/addon-styling@1.3.5--canary.77.5a17baa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
