### PR TITLE
Registry: Stop addon from being registered twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,6 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./dist/manager.js": {
-      "require": "./dist/manager.js",
-      "import": "./dist/manager.mjs",
-      "types": "./dist/manager.d.ts"
-    },
-    "./dist/preview.js": {
-      "require": "./dist/preview.js",
-      "import": "./dist/preview.mjs",
-      "types": "./dist/preview.d.ts"
-    },
     "./manager": {
       "require": "./dist/manager.js",
       "import": "./dist/manager.mjs",

--- a/preset.js
+++ b/preset.js
@@ -1,1 +1,10 @@
-module.exports = require("./dist/preset");
+const { webpackFinal, viteFinal } = require("./dist/preset");
+const preview = require("./dist/preview");
+const manager = require("./dist/manager");
+
+module.exports = {
+  webpackFinal,
+  viteFinal,
+  previewAnnotations: [preview],
+  managerEntries: [manager],
+};

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -4,11 +4,3 @@ import { viteFinal as vite } from "./vite/viteFinal";
 export const webpackFinal = webpack as any;
 
 export const viteFinal = vite as any;
-
-export const previewAnnotations = [
-  require.resolve("@storybook/addon-styling/preview"),
-];
-
-export const managerEntries = [
-  require.resolve("@storybook/addon-styling/manager"),
-];


### PR DESCRIPTION
## What changed
- Don't export manager and preview from preset
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.7--canary.88.040cffe.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-styling@1.3.7--canary.88.040cffe.0
  # or 
  yarn add @storybook/addon-styling@1.3.7--canary.88.040cffe.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
